### PR TITLE
Publish to GH pages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,66 @@
+---
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 5 * * 1'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    name: Build Jupyter Notebooks and HTML
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@19eac09b398e3d0c747adc7921926a6d802df4da  # v0.8.8
+        with:
+          cache: true
+          cache-write: true
+
+      - name: Build executed notebooks and HTML
+        run: pixi run build
+
+      - name: Upload executed notebooks as GitHub artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: executed-notebooks
+          path: _build/jupyter_execute/tutorials
+          if-no-files-found: error
+
+      - name: Upload HTML as GitHub artifact (for debugging)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build/html
+
+  deploy-gh-pages:
+    name: Deploy HTML to GitHub Pages
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy HTML to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Build docs
- Upload built docs as a GH artifact for programmatic access to built artifact.
- Publish via [deploy-pages](https://github.com/actions/deploy-pages) action.

Differences from https://github.com/danielballan/interactive-tutorial-demo/blob/main/.github/workflows/cd.yml:

- Do not upload `ipynb` versions to a `notebooks` branch. (We do not plan to do this.)
- Do not create a JupyterLite site. (Let's prototype this in a separate PR.)