### PR TITLE
Add an example of an exercise with a hidden solution

### DIFF
--- a/tutorials/executable/basics.md
+++ b/tutorials/executable/basics.md
@@ -4,7 +4,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.16.4
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -33,4 +33,23 @@ This cell has an expected error:
 :tags: [raises-exception]
 
 1 / 0
+```
+
+## Exercises
+
+Add one plus one.
+
+```{code-cell} ipython3
+# Write your solution here.
+```
+
+```{code-cell} ipython3
+---
+tags: [hide-cell]
+jupyter:
+  source_hidden: true
+---
+# Expand to reveal solution.
+
+1 + 1
 ```


### PR DESCRIPTION
This uses cell metadata to make a cell hidden by default but expandable, both in JupyterLab and in the rendered HTML.

```yaml
---
tags: [hide-cell]
jupyter:
  source_hidden: true
---
```

The `tags` operate on MyST. The `jupyter` key operates on JupyterLab. See references below.

## In JupyterLab

![image](https://github.com/user-attachments/assets/22f92997-d282-40d0-a8f0-7f6d7af64fd2)

![image](https://github.com/user-attachments/assets/21b4fc0b-1bfd-4139-bcb7-9f3d90a7abe2)

References:
- https://jupyterlab.readthedocs.io/en/3.5.x/api/interfaces/nbformat.icodecelljupytermetadata.html#source_hidden
- https://discourse.jupyter.org/t/hiding-code-cell-on-launch/1763/10?u=danielballan

## Rendered in HTML by MyST

![image](https://github.com/user-attachments/assets/0f02dadb-05d8-41b5-9941-54e4440d0303)

![image](https://github.com/user-attachments/assets/5399e9a2-3e2a-4f64-9e91-2470872c6f6d)

Reference: https://jupyterbook.org/en/stable/interactive/hiding.html#hide-entire-code-cells