### PR TITLE
BUG: we should return on the pytest exitval

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -46,6 +46,7 @@ myst-nb = ">=1.1"
 jupytext = ">=1.16"
 sphinx-book-theme = ">=1.1"
 sphinx-copybutton = ">=0.5"
+pytest-custom_exit_code = "*"
 
 [feature.py312.dependencies]
 python = "3.12.*"

--- a/test.sh
+++ b/test.sh
@@ -29,6 +29,12 @@ done
 
 pytest --nbval-lax -vv --suppress-no-test-exit-code --durations=10
 
+_exitval="$?"
+
+if [ $_exitval > 0 ]; then
+    exit $_exitval
+fi
+
 # Clean up ipynb files that were converted.  Any stray ipynb files that were
 # _not_ the result of conversion from Markdown will be left alone.
 for file in "${notebook_files[@]}"; do


### PR DESCRIPTION
This closes #54 

(note: this never comes up when running pytest directly in tox, or in the terminal but a typical problem that comes up when we factor out in a shell script)