### PR TITLE
Add thebe Live Code

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -15,6 +15,7 @@ extensions = [
     "myst_nb",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_thebe",
 ]
 
 myst_enable_extensions = [
@@ -55,6 +56,7 @@ html_theme_options = {
     "use_issues_button": True,
     "use_edit_page_button": True,
     "launch_buttons": {
-        "binderhub_url": "https://mybinder.org"
+        "binderhub_url": "https://mybinder.org",
+        "thebe": True,
     },
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,6 +27,7 @@ build = { cmd = [
 clean = "rm -rf _build/*"
 start = "jupyter lab  --FileContentsManager.preferred_dir tutorials"
 test = "bash ./test.sh"
+serve = "python -m http.server 8000 -d _build/html"
 
 [feature.base.activation]
 # Workaround overrides JupyterLab configuration (at the environment level) to

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,7 @@ pytest = ">=8.3.5,<9"
 nbval = ">=0.11.0,<0.12"
 jupytext = ">=1.17.1,<2"
 ipympl = ">=0.9"
+sphinx-thebe = ">=0.3.1"
 
 [feature.base.pypi-dependencies]
 sphinx = ">=8.0.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ sphinx
 myst-nb
 sphinx-book-theme
 sphinx-design
+sphinx-thebe
 ipympl
 sphinx-copybutton
 # For tutorials


### PR DESCRIPTION
Adds support for `sphinx-thebe` so you can run the code from within the JupyterBook HTML assets.

<img width="433" alt="image" src="https://github.com/user-attachments/assets/40672436-74b9-4c82-94ad-55408b5d7c14" />

<img width="650" alt="image" src="https://github.com/user-attachments/assets/c2349b42-1fb1-45b2-b36c-3204d93cc122" />
